### PR TITLE
Update 4.4-essential-apis-menu.md

### DIFF
--- a/4-back-end-development/4.4-essential-apis-menu.md
+++ b/4-back-end-development/4.4-essential-apis-menu.md
@@ -90,7 +90,7 @@ block_configure:
 
 The above code adds a `Configure block` contextual link to the `block` group. When a block is rendered for a user that has the appropriate permissions, a contextual link is displayed.
 
-![Contextual Links - Configure block](images/contextual-links.png "Contextual Links - Configure block")
+![Contextual Links - Configure block](images/contextual-link.png "Contextual Links - Configure block")
 
 Contextual links are rendered when they are included in a render array. (See: [Render API](4.4-essential-apis-render.md)).
 


### PR DESCRIPTION
Fixed link for contextual link screenshot.  The link to the image is actually located here - [https://github.com/WidgetsBurritos/d8-studyguide/blob/master/4-back-end-development/images/contextual-link.png](https://github.com/WidgetsBurritos/d8-studyguide/blob/master/4-back-end-development/images/contextual-link.png)