### PR TITLE
Update 3.3-twig-syntax.md

### DIFF
--- a/3-front-end-development/3.3-twig-syntax.md
+++ b/3-front-end-development/3.3-twig-syntax.md
@@ -153,7 +153,7 @@ From [Twig's official macro documentation](http://twig.sensiolabs.org/doc/2.x/ta
 - [drupal.org: Filters - Modifying Variables In Twig Templates](https://www.drupal.org/docs/8/theming/twig/filters-modifying-variables-in-twig-templates)
 - [weebpal.com: Drupal 8 Theming Essential Guide ](https://www.weebpal.com/blog/drupal-8-theming)
 - [sqndr.github.io: Twig Debug](https://sqndr.github.io/d8-theming-guide/twig/twig-debug.html)
-- [twig.sensiolabs.org: macro] ](http://twig.sensiolabs.org/doc/2.x/tags/macro.html)
+- [twig.sensiolabs.org: macro](http://twig.sensiolabs.org/doc/2.x/tags/macro.html)
 
 ---
 


### PR DESCRIPTION
Fix link to "twig.sensiolabs.org: macro".