### PR TITLE
Fix a ‘were’ to ‘where’ in section 1.2 javascript

### DIFF
--- a/1-fundamentals/1.2-javascript-jquery.md
+++ b/1-fundamentals/1.2-javascript-jquery.md
@@ -57,7 +57,7 @@ angular.angularjs:
 ```
 
 ## Attaching Javascript
-Once libraries have been defined, they need to be attached were they are needed.
+Once libraries have been defined, they need to be attached where they are needed.
 
 ### Attaching to All Pages
 To attach Javascript to all pages:


### PR DESCRIPTION
This is pretty self explanatory. Quick and simple fix to improve overall flow of reading experience.