### PR TITLE
Update 4.4 routing example to be more concise

### DIFF
--- a/4-back-end-development/4.4-essential-apis-routing.md
+++ b/4-back-end-development/4.4-essential-apis-routing.md
@@ -113,62 +113,88 @@ example.name:
 
 Now suppose we have a node with nid 3, and someone navigations to `/example/3`.
 
-This passes in the entire object with node 3, and not just the nid value.
+As an example, here's how we can pass in the entire node object with nid 3, and not just the nid value, and use that object in our controller.
 
-You can define behavior for custom placeholders like this:
+We can update our routing.yml file to add an explicit definition for our parameter:
 
 ```
-my_module.mymenu:
-  path: '/node/{my_menu}/mytab'
+example.name:
+  path: '/example/{a_node}'
   defaults:
-    _title: 'My Title'
-    _form: '\Drupal\mymodule\Form\MyModuleformControllerForm'
+    _controller: '\Drupal\example\Controller\ExampleController::content'
+  requirements:
+    _permission: 'access content'
   options:
     parameters:
-      my_menu:
-        type: my_menu
+      a_node:
+        type: a_node
 ```
 
 Then in `my_module.services.yml`:
 ```
 services:
-  my_menu:
-    class: Drupal\mymodule\ParamConverter\MyModuleParamConverter
+  a_node:
+    class: Drupal\example\ParamConverter\ExampleParamConverter
     tags:
       - { name: paramconverter }
 ```
 
-And finally creating `src/ParamConverter/MyModuleParamConverter.php`:
+And finally creating `src/ParamConverter/ExampleParamConverter.php`:
 ```php
 <?php
-namespace Drupal\mymodule\ParamConverter;
+
+namespace Drupal\example\ParamConverter;
 
 use Drupal\Core\ParamConverter\ParamConverterInterface;
 use Drupal\node\Entity\Node;
 use Symfony\Component\Routing\Route;
 
-class MyModuleParamConverter implements ParamConverterInterface {
+class ExampleParamConverter implements ParamConverterInterface {
   public function convert($value, $definition, $name, array $defaults) {
     return Node::load($value);
   }
 
   public function applies($definition, $name, Route $route) {
-    return (!empty($definition['type']) && $definition['type'] == 'my_menu');
+    return (!empty($definition['type']) && $definition['type'] == 'a_node');
   }
+
 }
+
 ?>
 ```
 
-Now inside your controller you will have access to an instantiated $my_menu object:
+Now inside your controller you will have access to an instantiated $a_node object:
 
 ```
-class MyModuleformControllerForm extends FormBase{
-  // ...
-  public function buildForm(array $form, FormStateInterface $form_state, NodeInterface $my_menu = NULL) {
-    // $my_menu will be converted object from convert function above.
+<?php
+
+namespace Drupal\example\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class ExampleController.
+ *
+ * @package Drupal\example_module\Controller
+ */
+class ExampleController extends ControllerBase {
+  /**
+   * Hello.
+   *
+   * @return string
+   *   Return Hello string.
+   */
+  public function content($name = "undefined", NodeInterface $a_node = NULL) {
+    return [
+      '#type' => 'markup',
+      '#markup' => $this->t('Node passed title: ' . $a_node->getTitle()),
+    ];
   }
-  // ...
+
 }
+
 ```
 
 ## Additional Resources


### PR DESCRIPTION
It was somewhat confusing at first to switch examples midstream, where the initial basic controller example turns into a Form example when it comes time to passing an instantiated converted parameter. This commit aims to address this by providing a complete example of passing the converted node object into the first simple controller.