### PR TITLE
Use variable for X-CSRF-Token header

### DIFF
--- a/2-site-building/2.9-web-services.md
+++ b/2-site-building/2.9-web-services.md
@@ -131,7 +131,7 @@ curl --include \
   --request POST \
   --user admin:password \
   --header 'Content-type: application/hal+json' \
-  --header "X-CSRF-Token: MVlPYsbKjzcNFqF_ODtAEkfHcjSe7lX37peTuShrOF8" \
+  --header "X-CSRF-Token: $x_csrf_token" \
   http://localhost:8888/entity/node?_format=hal_json \
   --data-binary '{"_links":{"type":{"href":"http://localhost:8888/rest/type/node/article"}},"title":[{"value":"My Node Title"}],"type":[{"target_id":"article"}]}'
 ```


### PR DESCRIPTION
Example uses a hardcoded token. It should use the variable which stores the actual token instead.