### PR TITLE
Add core/drupal disclaimer

### DIFF
--- a/1-fundamentals/1.2-javascript-jquery.md
+++ b/1-fundamentals/1.2-javascript-jquery.md
@@ -94,6 +94,18 @@ Instead of using `$(document).ready(function() {})`, as is common in jQuery
 development, it is better to make use of `Drupal.behaviors` as it will ensure
 code runs on normal page loads, ajax calls and inside [BigPipe](https://www.drupal.org/docs/8/core/modules/bigpipe/overview).
 
+To enable `Drupal.behaviors` you must add `core/drupal` as a Javascript dependency in your theme/module.
+
+```
+my-js-lib:
+  version: 1.x
+  js:
+    js/my-js-lib.js: {}
+  dependencies:
+    - core/drupal
+```
+
+
 Example from [Javascript API Overview](https://www.drupal.org/docs/8/api/javascript-api/javascript-api-overview):
 ```
 Drupal.behaviors.myBehavior = {


### PR DESCRIPTION
This PR adds a disclaimer about `core/drupal` being required for `Drupal.behaviors`.