### PR TITLE
Update try.github.io link

### DIFF
--- a/1-fundamentals/1.3-git.md
+++ b/1-fundamentals/1.3-git.md
@@ -32,7 +32,8 @@ It is recommended you learn git separately, but here are some commonly used comm
 ## Additional Resources
 - [Official Git Documentation](https://git-scm.com/)
 - [drupal.org - Git documentation](https://www.drupal.org/documentation/git)
-- [try.github.io - tryGit](https://try.github.io/levels/1/challenges/1)
+- [try.github.io - tryGit](https://try.github.io)
+- [Learn Git Branching](https://learngitbranching.js.org/)
 
 
 ---


### PR DESCRIPTION
The Link https://try.github.io/levels/1/challenges/1 is no longer valid. Let's link to https://learngitbranching.js.org/ instead.