### PR TITLE
Update 3.3-twig-syntax.md

### DIFF
--- a/3-front-end-development/3.3-twig-syntax.md
+++ b/3-front-end-development/3.3-twig-syntax.md
@@ -1,6 +1,6 @@
 # Twig Syntax
 
-From [Twig in Drupal 8](https://www.drupal.org/docs/8/theming/twig):
+From [Twig in Drupal](https://www.drupal.org/docs/theming-drupal/twig-in-drupal):
 > Twig is a template engine for PHP and it is part of the Symfony2 framework.
 >
 > In Drupal 8 Twig replaces PHPTemplate as the default templating engine. One of the results of this change is that all of the theme_* functions and PHPTemplate based `*.tpl.php` files have been replaced by `*.html.twig` template files.


### PR DESCRIPTION
Updated the title of the page being linked to, along with the precise URL, which was working before but it was a redirect. Also it was a little confusing before because it specifically mentioned Drupal 8.